### PR TITLE
2483

### DIFF
--- a/lc202512/main.go
+++ b/lc202512/main.go
@@ -1,7 +1,10 @@
 package main
 
 import (
+	"log"
 	"math"
+	"os"
+	"runtime"
 	"slices"
 	"sort"
 	"strconv"
@@ -9,6 +12,62 @@ import (
 )
 
 //lint:file-ignore U1000 Ignore all unused code, it's generated
+
+var (
+	debugEnabled = os.Getenv("DEBUG") == "true"
+	debugLogger  = log.New(os.Stdout, "DEBUG: ", log.Ldate|log.Ltime)
+)
+
+func debugLog(v ...any) {
+	if debugEnabled {
+		pc, _, _, ok := runtime.Caller(1)
+		if !ok {
+			debugLogger.Println(v...)
+			return
+		}
+		if fn := runtime.FuncForPC(pc); fn != nil {
+			name := fn.Name()
+			if lastDot := strings.LastIndex(name, "."); lastDot != -1 {
+				name = name[lastDot+1:]
+			}
+			args := append([]any{name + ":"}, v...)
+			debugLogger.Println(args...)
+		}
+	}
+}
+
+func BestClosingTime(customers string) int {
+	// 2483
+	//          YYNY
+	// prefixN 00011
+	// suffixY 32110
+	//         32121
+	n := len(customers)
+	prefixN := make([]int, n+1)
+	for i, c := range customers {
+		if c == 'N' {
+			prefixN[i+1] = prefixN[i] + 1
+		} else {
+			prefixN[i+1] = prefixN[i]
+		}
+	}
+	suffixY := make([]int, n+1)
+	for i := n - 1; i >= 0; i-- {
+		if customers[i] == 'Y' {
+			suffixY[i] = suffixY[i+1] + 1
+		} else {
+			suffixY[i] = suffixY[i+1]
+		}
+	}
+	closingHour, minPenalty := 0, math.MaxUint32
+	for i, nCount := range prefixN {
+		if nCount+suffixY[i] < minPenalty {
+			minPenalty = nCount + suffixY[i]
+			closingHour = i
+		}
+	}
+	return closingHour
+}
 
 func MinimumBoxes(apple []int, capacity []int) (boxCount int) {
 	// 3074

--- a/lc202512/main_test.go
+++ b/lc202512/main_test.go
@@ -4,6 +4,16 @@ import (
 	"fmt"
 )
 
+func ExampleBestClosingTime() {
+	fmt.Println(BestClosingTime("YYNY"))
+	fmt.Println(BestClosingTime("NNNN"))
+	fmt.Println(BestClosingTime("YYYY"))
+	// Unordered output:
+	// 2
+	// 0
+	// 4
+}
+
 func ExampleMinimumBoxes() {
 	fmt.Println(MinimumBoxes([]int{1, 3, 2}, []int{4, 3, 1, 5, 2}))
 	fmt.Println(MinimumBoxes([]int{5, 5, 5}, []int{2, 4, 2, 7}))


### PR DESCRIPTION
@gemini-cli /review

func BestClosingTime(customers string) int

You are given the customer visit log of a shop represented by a 0-indexed string customers consisting only of characters 'N' and 'Y':

if the ith character is 'Y', it means that customers come at the ith hour
whereas 'N' indicates that no customers come at the ith hour.
If the shop closes at the jth hour (0 <= j <= n), the penalty is calculated as follows:

For every hour when the shop is open and no customers come, the penalty increases by 1.
For every hour when the shop is closed and customers come, the penalty increases by 1.
Return the earliest hour at which the shop must be closed to incur a minimum penalty.

Note that if a shop closes at the jth hour, it means the shop is closed at the hour j.

 

Example 1:

Input: customers = "YYNY"
Output: 2
Explanation: 
- Closing the shop at the 0th hour incurs in 1+1+0+1 = 3 penalty.
- Closing the shop at the 1st hour incurs in 0+1+0+1 = 2 penalty.
- Closing the shop at the 2nd hour incurs in 0+0+0+1 = 1 penalty.
- Closing the shop at the 3rd hour incurs in 0+0+1+1 = 2 penalty.
- Closing the shop at the 4th hour incurs in 0+0+1+0 = 1 penalty.
Closing the shop at 2nd or 4th hour gives a minimum penalty. Since 2 is earlier, the optimal closing time is 2.
Example 2:

Input: customers = "NNNNN"
Output: 0
Explanation: It is best to close the shop at the 0th hour as no customers arrive.
Example 3:

Input: customers = "YYYY"
Output: 4
Explanation: It is best to close the shop at the 4th hour as customers arrive at each hour.
 

Constraints:

1 <= customers.length <= 105
customers consists only of characters 'Y' and 'N'.